### PR TITLE
Add translations for Flatpickr.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Require each js locale you need to your `vendor/assets/javascripts/alchemy/admin
 //= require alchemy_i18n/fr
 //= require select2_locale_de
 //= require select2_locale_fr
+//= require flatpickr/de
+//= require flatpickr/fr
 ```
 
 Or require all js translations at once by adding (**not recommended**)

--- a/app/assets/javascripts/alchemy_i18n.js
+++ b/app/assets/javascripts/alchemy_i18n.js
@@ -12,3 +12,10 @@
 //= require select2_locale_nl
 //= require select2_locale_ru
 //= require select2_locale_zh-CN
+//= require flatpickr/de
+//= require flatpickr/es
+//= require flatpickr/fr
+//= require flatpickr/it
+//= require flatpickr/nl
+//= require flatpickr/ru
+//= require flatpickr/zh

--- a/app/assets/javascripts/alchemy_i18n/de.js
+++ b/app/assets/javascripts/alchemy_i18n/de.js
@@ -23,6 +23,6 @@ Alchemy.translations.de = {
     datetime: "d.m.Y H:i",
     date: "d.m.Y",
     time: "H:i",
-    start_of_week: 1
+    time_24hr: true
   }
 };

--- a/app/assets/javascripts/alchemy_i18n/es.js
+++ b/app/assets/javascripts/alchemy_i18n/es.js
@@ -23,6 +23,6 @@ Alchemy.translations.es = {
     datetime: "d/m/Y H:i",
     date: "d/m/Y",
     time: "H:i",
-    start_of_week: 1
+    time_24hr: true
   }
 };

--- a/app/assets/javascripts/alchemy_i18n/fr.js
+++ b/app/assets/javascripts/alchemy_i18n/fr.js
@@ -23,6 +23,6 @@ Alchemy.translations.fr = {
     datetime: "d.m.Y H:i",
     date: "d.m.Y",
     time: "H:i",
-    start_of_week: 1
+    time_24hr: true
   }
 };

--- a/app/assets/javascripts/alchemy_i18n/it.js
+++ b/app/assets/javascripts/alchemy_i18n/it.js
@@ -23,6 +23,6 @@ Alchemy.translations.it = {
     datetime: "Y-m-d H:i",
     date: "Y-m-d",
     time: "H:i",
-    start_of_week: 1
+    time_24hr: true
   }
 };

--- a/app/assets/javascripts/alchemy_i18n/nl.js
+++ b/app/assets/javascripts/alchemy_i18n/nl.js
@@ -23,6 +23,6 @@ Alchemy.translations.nl = {
     datetime: "Y-m-d H:i",
     date: "Y-m-d",
     time: "H:i",
-    start_of_week: 1
+    time_24hr: true
   }
 };

--- a/app/assets/javascripts/alchemy_i18n/ru.js
+++ b/app/assets/javascripts/alchemy_i18n/ru.js
@@ -23,6 +23,6 @@ Alchemy.translations.ru = {
     datetime: "d.m.Y H:i",
     date: "d.m.Y",
     time: "H:i",
-    start_of_week: 1
+    time_24hr: true
   }
 };

--- a/app/assets/javascripts/alchemy_i18n/zh-CN.js
+++ b/app/assets/javascripts/alchemy_i18n/zh-CN.js
@@ -23,6 +23,6 @@ Alchemy.translations['zh-CN'] = {
     datetime: "Y-m-d H:i",
     date: "Y-m-d",
     time: "H:i",
-    start_of_week: 0
+    time_24hr: true
   }
 };

--- a/vendor/assets/javascripts/flatpickr/de.js
+++ b/vendor/assets/javascripts/flatpickr/de.js
@@ -1,0 +1,34 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.de = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var German = {
+      weekdays: {
+        shorthand: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
+        longhand: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
+      },
+      months: {
+        shorthand: ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
+        longhand: ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"]
+      },
+      firstDayOfWeek: 1,
+      weekAbbreviation: "KW",
+      rangeSeparator: " bis ",
+      scrollTitle: "Zum Ändern scrollen",
+      toggleTitle: "Zum Umschalten klicken"
+    };
+    fp.l10ns.de = German;
+    var de = fp.l10ns;
+
+    exports.German = German;
+    exports.default = de;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/es.js
+++ b/vendor/assets/javascripts/flatpickr/es.js
@@ -1,0 +1,34 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.es = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var Spanish = {
+      weekdays: {
+        shorthand: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
+        longhand: ["Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"]
+      },
+      months: {
+        shorthand: ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"],
+        longhand: ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"]
+      },
+      ordinal: function ordinal() {
+        return "º";
+      },
+      firstDayOfWeek: 1,
+      rangeSeparator: " a "
+    };
+    fp.l10ns.es = Spanish;
+    var es = fp.l10ns;
+
+    exports.Spanish = Spanish;
+    exports.default = es;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/fr.js
+++ b/vendor/assets/javascripts/flatpickr/fr.js
@@ -1,0 +1,38 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.fr = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var French = {
+      firstDayOfWeek: 1,
+      weekdays: {
+        shorthand: ["dim", "lun", "mar", "mer", "jeu", "ven", "sam"],
+        longhand: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
+      },
+      months: {
+        shorthand: ["janv", "févr", "mars", "avr", "mai", "juin", "juil", "août", "sept", "oct", "nov", "déc"],
+        longhand: ["janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre", "octobre", "novembre", "décembre"]
+      },
+      ordinal: function ordinal(nth) {
+        if (nth > 1) return "";
+        return "er";
+      },
+      rangeSeparator: " au ",
+      weekAbbreviation: "Sem",
+      scrollTitle: "Défiler pour augmenter la valeur",
+      toggleTitle: "Cliquer pour basculer"
+    };
+    fp.l10ns.fr = French;
+    var fr = fp.l10ns;
+
+    exports.French = French;
+    exports.default = fr;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/it.js
+++ b/vendor/assets/javascripts/flatpickr/it.js
@@ -1,0 +1,37 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.it = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var Italian = {
+      weekdays: {
+        shorthand: ["Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"],
+        longhand: ["Domenica", "Lunedì", "Martedì", "Mercoledì", "Giovedì", "Venerdì", "Sabato"]
+      },
+      months: {
+        shorthand: ["Gen", "Feb", "Mar", "Apr", "Mag", "Giu", "Lug", "Ago", "Set", "Ott", "Nov", "Dic"],
+        longhand: ["Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"]
+      },
+      firstDayOfWeek: 1,
+      ordinal: function ordinal() {
+        return "°";
+      },
+      rangeSeparator: " al ",
+      weekAbbreviation: "Se",
+      scrollTitle: "Scrolla per aumentare",
+      toggleTitle: "Clicca per cambiare"
+    };
+    fp.l10ns.it = Italian;
+    var it = fp.l10ns;
+
+    exports.Italian = Italian;
+    exports.default = it;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/nl.js
+++ b/vendor/assets/javascripts/flatpickr/nl.js
@@ -1,0 +1,38 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.nl = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var Dutch = {
+      weekdays: {
+        shorthand: ["zo", "ma", "di", "wo", "do", "vr", "za"],
+        longhand: ["zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag"]
+      },
+      months: {
+        shorthand: ["jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sept", "okt", "nov", "dec"],
+        longhand: ["januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"]
+      },
+      firstDayOfWeek: 1,
+      weekAbbreviation: "wk",
+      rangeSeparator: " tot ",
+      scrollTitle: "Scroll voor volgende / vorige",
+      toggleTitle: "Klik om te wisselen",
+      ordinal: function ordinal(nth) {
+        if (nth === 1 || nth === 8 || nth >= 20) return "ste";
+        return "de";
+      }
+    };
+    fp.l10ns.nl = Dutch;
+    var nl = fp.l10ns;
+
+    exports.Dutch = Dutch;
+    exports.default = nl;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/pl.js
+++ b/vendor/assets/javascripts/flatpickr/pl.js
@@ -1,0 +1,37 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.pl = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var Polish = {
+      weekdays: {
+        shorthand: ["Nd", "Pn", "Wt", "Śr", "Cz", "Pt", "So"],
+        longhand: ["Niedziela", "Poniedziałek", "Wtorek", "Środa", "Czwartek", "Piątek", "Sobota"]
+      },
+      months: {
+        shorthand: ["Sty", "Lut", "Mar", "Kwi", "Maj", "Cze", "Lip", "Sie", "Wrz", "Paź", "Lis", "Gru"],
+        longhand: ["Styczeń", "Luty", "Marzec", "Kwiecień", "Maj", "Czerwiec", "Lipiec", "Sierpień", "Wrzesień", "Październik", "Listopad", "Grudzień"]
+      },
+      rangeSeparator: " do ",
+      weekAbbreviation: "tydz.",
+      scrollTitle: "Przwiń aby zwiększyć",
+      toggleTitle: "Kliknij aby przełączyć",
+      firstDayOfWeek: 1,
+      ordinal: function ordinal() {
+        return ".";
+      }
+    };
+    fp.l10ns.pl = Polish;
+    var pl = fp.l10ns;
+
+    exports.Polish = Polish;
+    exports.default = pl;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/ru.js
+++ b/vendor/assets/javascripts/flatpickr/ru.js
@@ -1,0 +1,39 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.ru = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var Russian = {
+      weekdays: {
+        shorthand: ["Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
+        longhand: ["Воскресенье", "Понедельник", "Вторник", "Среда", "Четверг", "Пятница", "Суббота"]
+      },
+      months: {
+        shorthand: ["Янв", "Фев", "Март", "Апр", "Май", "Июнь", "Июль", "Авг", "Сен", "Окт", "Ноя", "Дек"],
+        longhand: ["Январь", "Февраль", "Март", "Апрель", "Май", "Июнь", "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"]
+      },
+      firstDayOfWeek: 1,
+      ordinal: function ordinal() {
+        return "";
+      },
+      rangeSeparator: " — ",
+      weekAbbreviation: "Нед.",
+      scrollTitle: "Прокрутите для увеличения",
+      toggleTitle: "Нажмите для переключения",
+      amPM: ["ДП", "ПП"],
+      yearAriaLabel: "Год"
+    };
+    fp.l10ns.ru = Russian;
+    var ru = fp.l10ns;
+
+    exports.Russian = Russian;
+    exports.default = ru;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/vendor/assets/javascripts/flatpickr/zh.js
+++ b/vendor/assets/javascripts/flatpickr/zh.js
@@ -1,0 +1,33 @@
+/* flatpickr v4.5.2, @license MIT */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.zh = {})));
+}(this, (function (exports) { 'use strict';
+
+    var fp = typeof window !== "undefined" && window.flatpickr !== undefined ? window.flatpickr : {
+      l10ns: {}
+    };
+    var Mandarin = {
+      weekdays: {
+        shorthand: ["周日", "周一", "周二", "周三", "周四", "周五", "周六"],
+        longhand: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
+      },
+      months: {
+        shorthand: ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"],
+        longhand: ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"]
+      },
+      rangeSeparator: " 至 ",
+      weekAbbreviation: "周",
+      scrollTitle: "滚动切换",
+      toggleTitle: "点击切换 12/24 小时时制"
+    };
+    fp.l10ns.zh = Mandarin;
+    var zh = fp.l10ns;
+
+    exports.Mandarin = Mandarin;
+    exports.default = zh;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));


### PR DESCRIPTION
Once Alchemy switches to using flatpickr as the default library for
date and time inputs, it will be very handy to have some translations.

Downloaded via https://cdnjs.com/libraries/flatpickr as there is no
canonical bundle.