### PR TITLE
add missing 'items_per_page' for german

### DIFF
--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -203,6 +203,7 @@ de:
     "Hide childpages": "Unterseiten ausblenden"
     hide_elements: "Elemente ausblenden"
     hide_element: "Element ausblenden"
+    items_per_page: "%{model_name} pro Seite"
     "Image missing": "Bild fehlt"
     "Image size": "Bildgröße"
     "Language successfully created": "Sprache wurde erfolgreich erstellt."


### PR DESCRIPTION
This PR just adds the key [`items_per_page`](https://github.com/AlchemyCMS/alchemy_cms/blob/7f39d1364bf78076ae16b5c0e3ef64a47eb3c2d0/config/locales/alchemy.en.yml#L203).