### PR TITLE
Add demo content translations from core

### DIFF
--- a/locales/alchemy.de.yml
+++ b/locales/alchemy.de.yml
@@ -18,6 +18,7 @@ de:
     #       search: Suche
     #
     page_layout_names:
+      index: Startseite
 
     # == Translations for element names
     # Just use the elements name like defined inside the config/alchemy/elements.yml file and translate it.
@@ -31,6 +32,7 @@ de:
     #       contactform: Kontaktformular
     #
     element_names:
+      article: Artikel
 
     # == Translated names for contents in elements.
     # Used for the content editor label inside the element editor view (The elements window)
@@ -50,6 +52,9 @@ de:
     #      show_caption: Zeige Bildunterschrift
     #
     content_names:
+      headline: Überschrift
+      text: Text
+      picture: Bild
 
     # === Translations for content validations
     # Used when a user did not enter (correct) values to the content field.
@@ -73,9 +78,22 @@ de:
         invalid: '%{field} hat das falsche Format'
         taken: '%{field} wurde schon benutzt'
 
+    # Hint texts for contents
+    content_hints:
+      headline: "Dies ist ein einzeiliger unformatierter Text"
+      picture: "Bilder werden in der Bibliothek gespeichert. Ein Bild kann mehrfach einem Element zugewiesen werden. Auch ein Bildauswahlwerkzeug ist in Alchemy integriert."
+      text: "Dies ist ein formatierbarer Textblock. Die Einstellungen des Editors können angepasst werden. Siehe http://guides.alchemy-cms.com/stable/customize_tinymce.html"
+
+    # Default texts for new contents created
     default_content_texts:
+      article_headline: "Willkommen auf Ihrer Alchemy Seite"
+      article_text: '<p>Als erstes sollte man sich mit der Struktur von Alchemy vertraut machen. <a class="external" href="http://guides.alchemy-cms.com/stable/alchemy_approach.html" target="_blank" data-link-target="blank">Mehr dazu in den Guidelines</a>.</p><p>Die wichtigsten beiden Dinge die man über Alchemy wissen muss sind Elemente und Seitentypen.</p><p><span style="text-decoration: underline;"><strong>Elemente:</strong></span></p><p>Mit Alchemy kann man eine Seite in Inhaltsbereiche aufteilen, Elemente. Diese Elemente werden aus verschiedenen Grundtypen (Essenzen) zusammengesetzt. Die Essenzen sind:</p><ul><li>EssenceText - <em>Eine Zeile Text</em></li><li>EssenceRichtext - <em>Ein TinyMCE basierter formatierter Textblock</em></li><li>EssencePicture - <em>Ein Verweis auf ein Bild</em></li><li>EssenceHtml - <em>HTML Code</em></li><li>EssenceSelect - <em>Eine Auswahl an Werten</em></li><li>EssenceBoolean - <em>Eine Checkbox</em></li></ul><p>Elemente werden in einer YAML Datei definiert: <strong>config/alchemy/elements.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/stable/elements.html" target="_blank" data-link-target="blank">Mehr über Elemente und wie sie definiert werden, kann in den Guidelines nachgelesen werden.</a></p><p><span style="text-decoration: underline;"><strong>Seitentypen:</strong></span></p><p>Es können verschiedene Seitentypen definiert werden. Diesen können Elemente zugewiesen und ihr Verhalten definiert werden.</p><p>Seitentypen werden ein einer YAML Datei definiert: <strong>config/alchemy/page_layouts.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/stable/page_layouts.html" target="_blank" data-link-target="blank">Mehr über das Erstellen von Seitentypen kann in den Guidelines nachgelesen werden.</a></p>'
       lorem: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
       corporate_lorem: "Appropriately enable sustainable growth strategies vis-a-vis holistic materials. Energistically orchestrate open-source e-tailers vis-a-vis plug-and-play best practices. Uniquely plagiarize client-centric opportunities whereas plug-and-play ideas. Distinctively reconceptualize backward-compatible partnerships vis-a-vis reliable total linkage. Interactively fabricate highly efficient networks for clicks-and-mortar content. Collaboratively reconceptualize holistic markets via 2.0 architectures."
+
+    # Hint texts for elements
+    element_hints:
+      article: "Dies ist ein Hinweistext für das Artikel Element. Dieser Text kann in der `config/locales/alchemy.de.yml` Datei angepasst werden."
 
     essence_pictures:
       css_classes:

--- a/locales/alchemy.es.yml
+++ b/locales/alchemy.es.yml
@@ -18,6 +18,7 @@ es:
     #       search: Buscar
     #
     page_layout_names:
+      index: Inicio
 
     # == Translations for element names
     # Just use the elements name like defined inside the config/alchemy/elements.yml file and translate it.
@@ -31,6 +32,7 @@ es:
     #       contactform: Contact form
     #
     element_names:
+      article: Artículo
 
     # == Translated names for contents in elements.
     # Used for the content editor label inside the element editor view (The elements window)
@@ -50,6 +52,9 @@ es:
     #      show_caption: Subtítulo de programa
     #
     content_names:
+      headline: Titular
+      text: Texto
+      picture: Imagen
 
     # === Translations for content validations
     # Used when a user did not enter (correct) values to the content field.
@@ -73,9 +78,22 @@ es:
         invalid: '%{field} tiene un formato incorrecto '
         taken: '%{field} ya está en uso'
 
+    # Hint texts for contents
+    content_hints:
+      headline: "Esta es una sencilla linea de texto sin formato"
+      picture: "Las imágenes se almacenan en la librería. Puedes asignar una imagen varias veces en tu sitio. Alchemy tiene una herramienta de recorte de imagen integrada."
+      text: "Este es un bloque de texto enriquecido mediante el editor TinyMCE. Puedes cambiar la configuración del editor. Ver http://guides.alchemy-cms.com/stable/customize_tinymce.html"
+
+    # Default texts for new contents created
     default_content_texts:
+      article_headline: "Bienvenido a tu primera página de Alchemy CMS"
+      article_text: '<p><strong>Como empezar.</strong></p><p>Lo primero de todo deberías leer sobre Alchemy y su arquitectura en las <a class="external" href="http://guides.alchemy-cms.com/stable/alchemy_approach.html" target="_blank" data-link-target="blank">guías</a>.</p><p>Las cosas más importantes que debes saber sobre Alchemy son elementos (<i>elements</i>) y disposiciones de página (<i>page layouts</i>).</p><p><span style="text-decoration: underline;"><strong>Elementos:</strong></span></p><p>Con Alchemy puedes dividir las páginas en partes de contenido, elementos. Estos elementos se pueden definir mediante varios tipos de contenido básicos: esencias (<i>essences</i>). Las esencias básicas son:</p><ul><li>EssenceText - <em>Un única línea de texto</em></li><li>EssenceRichtext - <em>Un bloque de texto formateado mediante TinyMCE</em></li><li>EssencePicture - <em>Una referencia a una imagen</em></li><li>EssenceHtml - <em>Código HTML empotrado</em></li><li>EssenceSelect - <em>Una selección de valores</em></li><li>EssenceBoolean - <em>Una casilla de verificación</em></li></ul><p>Los elementos se definen en el fichero YAML <strong>config/alchemy/elements.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/stable/elements.html" target="_blank" data-link-target="blank">Lee más sobre elementos y cómo definirlos en las guías.</a></p><p><span style="text-decoration: underline;"><strong>Tipos de página:</strong></span></p><p>Puedes definir varios tipos de páginas, llamados disposiciones de páginas (<i>page layouts</i>). Puedes asignar elementos a las disposiciones de páginas y controlar cómo se comportan los elementos y una página con una disposición concreta.</p><p>Las disposiciones de páginas se definen en el fichero YAML <strong>config/alchemy/page_layouts.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/stable/page_layouts.html" target="_blank" data-link-target="blank">Lee más sobre definir disposiciones de páginas en las guías.</a></p>'
       lorem: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
       corporate_lorem: "Appropriately enable sustainable growth strategies vis-a-vis holistic materials. Energistically orchestrate open-source e-tailers vis-a-vis plug-and-play best practices. Uniquely plagiarize client-centric opportunities whereas plug-and-play ideas. Distinctively reconceptualize backward-compatible partnerships vis-a-vis reliable total linkage. Interactively fabricate highly efficient networks for clicks-and-mortar content. Collaboratively reconceptualize holistic markets via 2.0 architectures."
+
+    # Hint texts for elements
+    element_hints:
+      article: "Este es el texto de ayuda del elemento artículo. Puedes cambiar este texto en `config/locales/alchemy.en.yml`. Siéntete libre de cambiarlo a tu gusto, es tuyo."
 
     essence_pictures:
       css_classes:


### PR DESCRIPTION
These translation used to live in core and get copied over during installation. It makes sense to have them in here.