### PR TITLE
Add translations for menu names

### DIFF
--- a/locales/alchemy.de.yml
+++ b/locales/alchemy.de.yml
@@ -6,6 +6,20 @@ de:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Seitenleistenmenü
+    #
+    menu_names:
+      main_menu: Hauptmenü
+      footer_menut: Footermenü
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.es.yml
+++ b/locales/alchemy.es.yml
@@ -6,6 +6,20 @@ es:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Menú de barra lateral
+    #
+    menu_names:
+      main_menu: Menú principal
+      footer_menut: Menú de pie de página
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.fr.yml
+++ b/locales/alchemy.fr.yml
@@ -6,6 +6,20 @@ fr:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Menu latéral
+    #
+    menu_names:
+      main_menu: Menu principal
+      footer_menut: Menu de bas de page
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.it.yml
+++ b/locales/alchemy.it.yml
@@ -6,6 +6,18 @@ it:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Side bar menu (?)
+    #
+    menu_names:
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.nl.yml
+++ b/locales/alchemy.nl.yml
@@ -6,6 +6,18 @@ nl:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Side bar menu (?)
+    #
+    menu_names:
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.pl.yml
+++ b/locales/alchemy.pl.yml
@@ -6,6 +6,18 @@ pl:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Side bar menu (?)
+    #
+    menu_names:
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.ru.yml
+++ b/locales/alchemy.ru.yml
@@ -6,6 +6,18 @@ ru:
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
 
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Seitenleistenmenü
+    #
+    menu_names:
+
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.
     #

--- a/locales/alchemy.zh-CN.yml
+++ b/locales/alchemy.zh-CN.yml
@@ -5,6 +5,17 @@ zh-CN:
   # = Alchemy Translations
   # All translations used in Alchemy CMS are inside this alchemy namespace.
   alchemy:
+    # == Translations for menu names
+    # Just use the menu name like defined inside the config/alchemy/menus.yml file and translate it.
+    # We're providing main and footer menu here as a convenience.
+    # Example:
+    #
+    # de:
+    #   alchemy:
+    #     menu_names:
+    #       sidebar_menu: Side bar menu (?)
+    #
+    menu_names:
 
     # == Translations for page_layout names
     # Just use the page_layouts name like defined inside the config/alchemy/page_layouts.yml file and translate it.


### PR DESCRIPTION
We're translating menu names in Alchemy now, so we need some
translations. I added German, Spanish and French as those are languages
I feel comfortable translating, and only added the I18n key for menus
for the other languages.