### PR TITLE
Fix tinymce sprockets include in generator

### DIFF
--- a/lib/generators/alchemy_i18n/install/install_generator.rb
+++ b/lib/generators/alchemy_i18n/install/install_generator.rb
@@ -47,7 +47,7 @@ module AlchemyI18n
       def append_manifest
         locales.each do |locale|
           append_file 'app/assets/config/manifest.js', <<~MANIFEST
-            //= link vendor/assets/javascripts/tinymce/langs/#{locale}.js
+            //= link tinymce/langs/#{locale}.js
           MANIFEST
         end
       end


### PR DESCRIPTION
Sprockets will look in `vendor/javascripts` for the TinyMCE translations, prepending
the path however breaks the loading mechanism.