### PR TITLE
Copy Flatpickr translations in generator

### DIFF
--- a/lib/generators/alchemy_i18n/install/install_generator.rb
+++ b/lib/generators/alchemy_i18n/install/install_generator.rb
@@ -26,6 +26,7 @@ module AlchemyI18n
           copy_file File.join('locales', yml_filename), Rails.root.join('config', 'locales', yml_filename)
           js_filename = "#{locale}.js"
           copy_file File.join('app', 'assets', 'javascripts', 'alchemy_i18n', js_filename), Rails.root.join('vendor', 'assets', 'javascripts', 'alchemy_i18n', js_filename)
+          copy_file File.join('vendor', 'assets', 'javascripts', 'flatpickr', js_filename), Rails.root.join('vendor', 'assets', 'javascripts', 'flatpickr', js_filename)
         end
       end
 


### PR DESCRIPTION
Without this commit, we cannot use this gem only in the `development`
bundler group.