### PR TITLE
Alchemy v5 compatibility

### DIFF
--- a/app/assets/javascripts/alchemy_i18n/de.js
+++ b/app/assets/javascripts/alchemy_i18n/de.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations.de = {
   allowed_chars: 'von %{count} Zeichen',
   cancel: 'Abbrechen',

--- a/app/assets/javascripts/alchemy_i18n/es.js
+++ b/app/assets/javascripts/alchemy_i18n/es.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations.es = {
   allowed_chars: 'de %{count} caracteres',
   cancel: 'Cancelar',

--- a/app/assets/javascripts/alchemy_i18n/fr.js
+++ b/app/assets/javascripts/alchemy_i18n/fr.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations.fr = {
   allowed_chars: 'von %{count} signes',
   cancel: 'abandonner',

--- a/app/assets/javascripts/alchemy_i18n/it.js
+++ b/app/assets/javascripts/alchemy_i18n/it.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations.it = {
   allowed_chars: 'di %{count} caratteri',
   cancel: 'Annulla',

--- a/app/assets/javascripts/alchemy_i18n/nl.js
+++ b/app/assets/javascripts/alchemy_i18n/nl.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations.nl = {
   allowed_chars: 'of %{count} chars',
   cancel: 'Annuleren',

--- a/app/assets/javascripts/alchemy_i18n/ru.js
+++ b/app/assets/javascripts/alchemy_i18n/ru.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations.ru = {
   allowed_chars: '%{count} знаков',
   cancel: 'Отмена',

--- a/app/assets/javascripts/alchemy_i18n/zh-CN.js
+++ b/app/assets/javascripts/alchemy_i18n/zh-CN.js
@@ -1,5 +1,4 @@
-//= require alchemy/alchemy.translations
-
+Alchemy.translations = Alchemy.translations || {};
 Alchemy.translations['zh-CN'] = {
   allowed_chars: '%{count} 个字符',
   cancel: '取消',


### PR DESCRIPTION
This is a breaking change, since the require statement is needed for Alchemy v4, but not for Alchemy v5.
I don't know how to handle this, I think it's necessary to have a new major version here.

Closes #32 