### PR TITLE
Allow Alchemy 6

### DIFF
--- a/alchemy_i18n.gemspec
+++ b/alchemy_i18n.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,locales,lib,vendor}/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
 
-  s.add_dependency "alchemy_cms", [">= 4.4.0.a", "< 6.0"]
+  s.add_dependency "alchemy_cms", [">= 4.4.0.a", "< 6.1"]
   s.add_dependency "rails-i18n"
 
   s.add_development_dependency "github_changelog_generator"


### PR DESCRIPTION
Relax dependency constraint to allow Alchemy v6.0