### PR TITLE
Do not change config.available_locales in install generator

### DIFF
--- a/lib/generators/alchemy_i18n/install/install_generator.rb
+++ b/lib/generators/alchemy_i18n/install/install_generator.rb
@@ -53,12 +53,6 @@ module AlchemyI18n
         end
       end
 
-      def add_rails_i18n
-        environment do
-          "config.i18n.available_locales = #{locales.map(&:to_sym).inspect}"
-        end
-      end
-
       def add_russian_gem
         if locales.include?('ru')
           gem 'russian', '~> 0.6'


### PR DESCRIPTION
This bit of code changes the host's app `application.rb` file,
restricting the available locales to ones that are not English. I have
an app that has both English and German as locales, and I have to delete
the added line every time I run the installer. I think it should stay
the host app's responsibility to choose what locales are good for it.