### PR TITLE
Import flatpickr translations into Alchemy admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # AlchemyCMS Translations
 
-Translations files for AlchemyCMS 6.0 and above.
+Translations files for AlchemyCMS 7.0 and above.
 
 ## Alchemy version
 
-For a Alchemy 5.3 compatible version use v2.3.1 or the `2.3-stable` branch.
+- For a Alchemy 6.1 compatible version use v3.2.0 or the `3.2-stable` branch.
+- For a Alchemy 5.3 compatible version use v2.3.1 or the `2.3-stable` branch.
 
 ## Installation
 

--- a/alchemy_i18n.gemspec
+++ b/alchemy_i18n.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,locales,lib,vendor}/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
 
-  s.add_dependency "alchemy_cms", [">= 6.0.0", "< 8"]
+  s.add_dependency "alchemy_cms", [">= 7.0.4", "< 8"]
   s.add_dependency "rails-i18n"
 
   s.add_development_dependency "github_changelog_generator"

--- a/lib/alchemy_i18n/engine.rb
+++ b/lib/alchemy_i18n/engine.rb
@@ -5,6 +5,10 @@ module AlchemyI18n
       pattern = locales.empty? ? "*" : "{#{locales.join ","}}"
       files = Dir[root.join("locales", "alchemy.#{pattern}.yml")]
       I18n.load_path.concat(files)
+      locales.each do |locale|
+        Alchemy.importmap.pin "flatpickr/#{locale}.js", to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/#{locale}.js"
+        Alchemy.admin_js_imports << "flatpickr/#{locale}.js"
+      end
     end
   end
 end

--- a/lib/generators/alchemy_i18n/install/install_generator.rb
+++ b/lib/generators/alchemy_i18n/install/install_generator.rb
@@ -37,24 +37,6 @@ module AlchemyI18n
         end
       end
 
-      def append_pack
-        app_root = Rails.root
-        config_file = app_root.join("config", "webpacker.yml")
-        if config_file.exist?
-          webpack_config = YAML.load_file(config_file)[Rails.env]
-          pack = app_root.join(
-            webpack_config["source_path"],
-            webpack_config["source_entry_path"],
-            "alchemy/admin.js"
-          )
-        else
-          pack = app_root.join("app/javascript/alchemy_admin.js")
-        end
-        additional_locales.each { |locale| append_file pack, <<~PACK }
-          import "flatpickr/dist/l10n/#{locale}.js"
-        PACK
-      end
-
       def add_rails_i18n
         environment do
           "config.i18n.available_locales = #{locales.inspect}"


### PR DESCRIPTION
Alchemy 7.0 uses importmaps and JS modules for
flatpickr (and other JS dependencies). We need
to register the translations as additional JS
module imports in order to be available to
Flatpickr.

This raises the supported Alchemy version to >= 7.0.4 because we need the ability to add additional admin JS module imports. 

See https://github.com/AlchemyCMS/alchemy_cms/pull/2588