### PR TITLE
Do not attempt to load en flatpickr locale

### DIFF
--- a/lib/alchemy_i18n/engine.rb
+++ b/lib/alchemy_i18n/engine.rb
@@ -1,7 +1,7 @@
 module AlchemyI18n
   class Engine < ::Rails::Engine
     initializer "alchemy-i18n" do |app|
-      locales = Array(app.config.i18n.available_locales)
+      locales = Array(app.config.i18n.available_locales).reject { |l| l == :en }
       pattern = locales.empty? ? "*" : "{#{locales.join ","}}"
       files = Dir[root.join("locales", "alchemy.#{pattern}.yml")]
       I18n.load_path.concat(files)


### PR DESCRIPTION
It does not exist and projects might still allow `:en` locale.