### PR TITLE
Use at least Alchemy 7.1.0-b1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms', branch: 'main'
 gem 'localeapp', '~> 3.0'
 gem 'dotenv', '~> 2.2'

--- a/alchemy_i18n.gemspec
+++ b/alchemy_i18n.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,locales,lib,vendor}/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
 
-  s.add_dependency "alchemy_cms", ["> 7.0", "< 8"]
+  s.add_dependency "alchemy_cms", [">= 7.1.0-b1", "< 8"]
   s.add_dependency "rails-i18n"
 
   s.add_development_dependency "github_changelog_generator"


### PR DESCRIPTION
We updated Tinymce translations to v6 and only Alchemy 7.1 uses that version. 