### PR TITLE
Move JS translations into partials

### DIFF
--- a/app/assets/javascripts/alchemy_i18n.js
+++ b/app/assets/javascripts/alchemy_i18n.js
@@ -1,7 +1,0 @@
-//= require alchemy_i18n/de
-//= require alchemy_i18n/es
-//= require alchemy_i18n/fr
-//= require alchemy_i18n/it
-//= require alchemy_i18n/nl
-//= require alchemy_i18n/ru
-//= require alchemy_i18n/zh-CN

--- a/app/views/alchemy/admin/translations/_de.js
+++ b/app/views/alchemy/admin/translations/_de.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {}
-Alchemy.translations.de = {
+Alchemy.translations = {
   allowed_chars: "von %{count} Zeichen",
   cancel: "Abbrechen",
   cancelled: "Abgebrochen",

--- a/app/views/alchemy/admin/translations/_es.js
+++ b/app/views/alchemy/admin/translations/_es.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {};
-Alchemy.translations.es = {
+Alchemy.translations = {
   allowed_chars: 'de %{count} caracteres',
   cancel: 'Cancelar',
   cancelled: 'Cancelado',

--- a/app/views/alchemy/admin/translations/_fr.js
+++ b/app/views/alchemy/admin/translations/_fr.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {};
-Alchemy.translations.fr = {
+Alchemy.translations = {
   allowed_chars: 'de %{count} caractères',
   cancel: 'abandonner',
   cancelled: 'annulé',

--- a/app/views/alchemy/admin/translations/_it.js
+++ b/app/views/alchemy/admin/translations/_it.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {};
-Alchemy.translations.it = {
+Alchemy.translations = {
   allowed_chars: 'di %{count} caratteri',
   cancel: 'Annulla',
   cancelled: 'Annullato',

--- a/app/views/alchemy/admin/translations/_nl.js
+++ b/app/views/alchemy/admin/translations/_nl.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {};
-Alchemy.translations.nl = {
+Alchemy.translations = {
   allowed_chars: 'of %{count} chars',
   cancel: 'Annuleren',
   cancelled: 'Afgebroken',

--- a/app/views/alchemy/admin/translations/_ru.js
+++ b/app/views/alchemy/admin/translations/_ru.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {};
-Alchemy.translations.ru = {
+Alchemy.translations = {
   allowed_chars: '%{count} знаков',
   cancel: 'Отмена',
   cancelled: 'Отменено',

--- a/app/views/alchemy/admin/translations/_zh-CN.js
+++ b/app/views/alchemy/admin/translations/_zh-CN.js
@@ -1,5 +1,4 @@
-Alchemy.translations = Alchemy.translations || {};
-Alchemy.translations['zh-CN'] = {
+Alchemy.translations = {
   allowed_chars: '%{count} 个字符',
   cancel: '取消',
   cancelled: '已取消',


### PR DESCRIPTION
Alchemy will load just the locale it needs in the
head of the admin document, so it does not have to deal with async loading of ES modules.

Necessary for https://github.com/AlchemyCMS/alchemy_cms/pull/3233