### PR TITLE
Add XML to show_page_in_sitemap translations across all locales

### DIFF
--- a/locales/alchemy.de.yml
+++ b/locales/alchemy.de.yml
@@ -749,7 +749,7 @@ de:
     show_elements_from_page: "Elemente dieser Seite anzeigen"
     show_eq: "EQ anzeigen"
     show_navigation: "Navigation anzeigen"
-    show_page_in_sitemap: "Seite in der Sitemap zeigen"
+    show_page_in_sitemap: "Seite in der XML-Sitemap anzeigen."
     signup_mail_delivery_error: "Einrichtungs-E-Mail konnte nicht verschickt werden. Bitte überprüfen Sie die Mail Einstellungen."
     small_thumbnails: "kleine Miniaturbilder"
     subject: "Betreff"

--- a/locales/alchemy.es.yml
+++ b/locales/alchemy.es.yml
@@ -668,7 +668,7 @@ es:
     show_elements_from_page: "Mostrar todos los elementos de esta página"
     show_eq: "Mostrar EQ"
     show_navigation: "Mostrar en navegación"
-    show_page_in_sitemap: "Mostar página en mapa del sitio."
+    show_page_in_sitemap: "Mostrar página en el sitemap XML."
     signup_mail_delivery_error: "El correo de registro no se pudo enviar. Por favor revisa tu configuración de correo."
     small_thumbnails: "Miniaturas pequeñas"
     subject: "Asunto"

--- a/locales/alchemy.fr.yml
+++ b/locales/alchemy.fr.yml
@@ -579,7 +579,7 @@ fr:
     show_elements_from_page: "Voir les articles sur cette page"
     show_eq: "afficher EQ"
     show_navigation: "Afficher la navigation"
-    show_page_in_sitemap: "Voir la page dans le plan du site"
+    show_page_in_sitemap: "Afficher la page dans le sitemap XML"
     signup_mail_delivery_error: "Mise en place e-mail n’a pas pu être envoyé. S’il vous plaît vérifier les paramètres de messagerie."
     small_thumbnails: "Petites images de miniature"
     subject: "Concerne"

--- a/locales/alchemy.it.yml
+++ b/locales/alchemy.it.yml
@@ -569,7 +569,7 @@ it:
     show_elements_from_page: "Mostra tutti gli elementi di questa pagina"
     show_eq: "Mostra EQ"
     show_navigation: "Mostra in navigazione"
-    show_page_in_sitemap: "Mostra la pagina nella sitemap."
+    show_page_in_sitemap: "Mostra la pagina nella sitemap XML."
     signup_mail_delivery_error: "Non è stato possibile consegnare la mail di signup. Ricontrolla le impostazioni dell'email."
     small_thumbnails: "Thumbnail piccoli"
     subject: "Soggetto"

--- a/locales/alchemy.nb-NO.yml
+++ b/locales/alchemy.nb-NO.yml
@@ -679,7 +679,7 @@ nb-NO:
     show_elements_from_page: Vis alle elementer fra denne siden
     show_eq: Vis EQ
     show_navigation: Vi i navigasjon
-    show_page_in_sitemap: Vis sider i sidekart.
+    show_page_in_sitemap: "Vis side i XML-sitemap."
     signup_mail_delivery_error: Registrerings-e-post kunne ikke leveres. Vennligst sjekk e-post-innstillingene dine.
     sitemap_editor_info:
     small_thumbnails: Små forhåndsvisninger

--- a/locales/alchemy.nl.yml
+++ b/locales/alchemy.nl.yml
@@ -565,7 +565,7 @@ nl:
     show_elements_from_page: "Alle elementen van deze pagina weergeven"
     show_eq: "EQ weergeven"
     show_navigation: "In navigatie weergeven"
-    show_page_in_sitemap: "Pagina in sitemap weergeven."
+    show_page_in_sitemap: "Pagina in XML-sitemap weergeven."
     signup_mail_delivery_error: "Registratiemail kan niet worden bezorgd. Controleer de e-mailinstellingen."
     small_thumbnails: "Kleine thumbnails"
     subject: "Onderwerp"

--- a/locales/alchemy.pl.yml
+++ b/locales/alchemy.pl.yml
@@ -559,7 +559,7 @@ pl:
     show_elements_from_page: "Show all elements from this page"
     show_eq: "Show EQ"
     show_navigation: "Show in navigation"
-    show_page_in_sitemap: "Show page in sitemap."
+    show_page_in_sitemap: "Pokaż stronę w sitemap XML."
     signup_mail_delivery_error: "Signup mail could not be delivered. Please check your mail settings."
     small_thumbnails: "Small thumbnails"
     subject: "Subject"

--- a/locales/alchemy.ru.yml
+++ b/locales/alchemy.ru.yml
@@ -555,7 +555,7 @@ ru:
     show_elements_from_page: "Показать эелементы страницы"
     show_eq: "Показать EQ"
     show_navigation: "Отображать в навигации"
-    show_page_in_sitemap: "Отображать страницу в sitemap."
+    show_page_in_sitemap: "Отображать страницу в XML-карте сайта."
     signup_mail_delivery_error: "Почта не может быть доставлена новому пользователю. Проверьте настройки почты."
     small_thumbnails: "Маленькие миниатюры"
     subject: "Тема"

--- a/locales/alchemy.zh-CN.yml
+++ b/locales/alchemy.zh-CN.yml
@@ -572,7 +572,7 @@ zh-CN:
     show_elements_from_page: "在这个页面显示所有元素"
     show_eq: "显示EQ"
     show_navigation: "在导航中显示"
-    show_page_in_sitemap: "在站点地图中显示页面。"
+    show_page_in_sitemap: "在 XML 站点地图中显示页面。"
     signup_mail_delivery_error: "无法发送注册邮件。请检查你的邮件设置。"
     small_thumbnails: "小缩略图"
     subject: "主题"


### PR DESCRIPTION
Clarify show_page_in_sitemap label to reference XML Sitemap explicitly                                                                                                                                                                 

The previous translations for the show_page_in_sitemap checkbox label were vague (e.g. "Show page in sitemap", "Voir la page dans le plan du site"). It was not immediately clear to users what file or system was affected.

By including XML in all translations, the label now clearly communicates that checking this option controls whether the page appears in the sitemap.xml file — making the checkbox's purpose unambiguous regardless of the user's language.